### PR TITLE
Basic docker setup

### DIFF
--- a/containers/Dockerfile.microcosm
+++ b/containers/Dockerfile.microcosm
@@ -1,0 +1,34 @@
+FROM golang:1.7
+MAINTAINER <>
+
+RUN apt-get -y update
+RUN apt-get -y install curl iproute2 netbase vim screen openssl
+
+ARG WEB_DOMAIN=dev.microco.sm
+ENV WEB_DOMAIN $WEB_DOMAIN
+
+ARG CODE_HOME=/go/src/github.com/buro9/microcosm
+ENV CODE_HOME $CODE_HOME
+
+RUN mkdir -p /etc/ssl/certs \
+    && openssl req -x509 -newkey rsa:4096 -nodes -days 999 \
+       -subj "/CN=$WEB_DOMAIN" \
+       -keyout /etc/ssl/certs/$WEB_DOMAIN.key \
+       -out /etc/ssl/certs/$WEB_DOMAIN.crt
+
+COPY  . $CODE_HOME
+WORKDIR $CODE_HOME
+
+RUN make
+
+EXPOSE 80 443
+
+ENV MICROCOSM_WEB_CERT_FILE /etc/ssl/certs/$WEB_DOMAIN.crt
+ENV MICROCOSM_WEB_KEY_FILE /etc/ssl/certs/$WEB_DOMAIN.key
+ENV MICROCOSM_WEB_API_CLIENT_SECRET "yolopolo"
+
+RUN ln -s $CODE_HOME/web/files /srv/microcosm-web
+
+# Default entrypoint: web layer
+ENTRYPOINT "${CODE_HOME}/bin/microcosm-web"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '2'
+
+services:
+
+  web:
+    image: microcosm
+    build:
+      context: .
+      dockerfile: ./containers/Dockerfile.microcosm
+    ports:
+     - "80:80"
+     - "443:443"
+    volumes:
+     - .:/go/src/github/buro9/microcosm
+    depends_on:
+     - cache
+
+  db:
+    image: "postgres:9.6"
+
+  cache:
+    image: "memcached:latest"


### PR DESCRIPTION
Useful to spin up a working stack quickly.

* `Dockerfile` to build a microcosm image (just the current `make` output, ie `microcosm-web`) 
  * Creates a self-signed cert for `dev.microco.sm`.
* `docker-compose.yml` to start `microcosm-web` and as well as `memcached` and `pgsql`.

1. Install docker
1. `docker-compose build`
1. `docker-compose up`

Need a proper `api` to point at, with a real hostname. Currently https://localhost produces an error in `ApiRootFromRequest` as it tries to do a DNS lookup (?) on `localhost`, and `dev.microco.sm` is blocked due to HSTS.