### PR TITLE
Strip port number for Host in ApiRootFromRequest() before API lookup

### DIFF
--- a/web/api/api.go
+++ b/web/api/api.go
@@ -35,8 +35,8 @@ var (
 func ApiRootFromRequest(req *http.Request) (string, error) {
 	// remove :port from req.Host if present
 	var hostName string
-	if cPos := strings.Index(req.Host, ":"); cPos > -1 {
-		hostName = req.Host[0:cPos]
+	if portPos := strings.Index(req.Host, ":"); portPos > -1 {
+		hostName = req.Host[0:portPos]
 	} else {
 		hostName = req.Host
 	}


### PR DESCRIPTION
Separating this from my prometheus branch:

Port number suffix in `req.Host` trips up the API lookup, so remove it before proceeding.

Prometheus always appends the port number when it calls for metrics:

`web_1         | 2017/03/16 06:14:39 [..] "GET http://dev.microcosmcc.com:80/metrics HTTP/1.1" from 172.18.0.5 - 200 1132B in 6.216271ms`